### PR TITLE
Use filter_complex_script FFMPEG argument if filter length is too long

### DIFF
--- a/lib/options/custom.js
+++ b/lib/options/custom.js
@@ -204,7 +204,7 @@ module.exports = function(proto) {
     var complexFiltersArgs = utils.makeFilterStrings(spec).join(';');
     if (complexFiltersArgs.length >= maxLengthArgument) {
       const tmpFilePath = tmp.fileSync().name;
-      fs.writeFileSync(complexFiltersFile, tmpFilePath);
+      fs.writeFileSync(tmpFilePath, complexFiltersArgs);
 
       this._complexFilters('-filter_complex_script', complexFiltersFile);
     } else {

--- a/lib/options/custom.js
+++ b/lib/options/custom.js
@@ -203,10 +203,10 @@ module.exports = function(proto) {
     var maxLengthArgument = 24 * 1024
     var complexFiltersArgs = utils.makeFilterStrings(spec).join(';');
     if (complexFiltersArgs.length >= maxLengthArgument) {
-      const tmpFilePath = tmp.fileSync().name;
+      const tmpFilePath = tmp.fileSync({ postfix: '.txt' }).name;
       fs.writeFileSync(tmpFilePath, complexFiltersArgs);
 
-      this._complexFilters('-filter_complex_script', complexFiltersFile);
+      this._complexFilters('-filter_complex_script', tmpFilePath);
     } else {
       this._complexFilters('-filter_complex', complexFiltersArgs);
     }

--- a/lib/options/custom.js
+++ b/lib/options/custom.js
@@ -1,6 +1,8 @@
 /*jshint node:true*/
 'use strict';
 
+var fs = require('fs');
+var tmp = require('tmp-promise');
 var utils = require('../utils');
 
 
@@ -196,7 +198,18 @@ module.exports = function(proto) {
       spec = [spec];
     }
 
-    this._complexFilters('-filter_complex', utils.makeFilterStrings(spec).join(';'));
+    // If complex filters arguments length is greater than a maximum,
+    // use filter_complex_script to pass a file with the filters into it.
+    var maxLengthArgument = 24 * 1024
+    var complexFiltersArgs = utils.makeFilterStrings(spec).join(';');
+    if (complexFiltersArgs.length >= maxLengthArgument) {
+      const tmpFilePath = tmp.fileSync().name;
+      fs.writeFileSync(complexFiltersFile, tmpFilePath);
+
+      this._complexFilters('-filter_complex_script', complexFiltersFile);
+    } else {
+      this._complexFilters('-filter_complex', complexFiltersArgs);
+    }
 
     if (Array.isArray(map)) {
       var self = this;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,109 @@
+{
+  "name": "fluent-ffmpeg",
+  "version": "2.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "requires": {
+        "rimraf": "^2.6.3"
+      }
+    },
+    "tmp-promise": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.2.tgz",
+      "integrity": "sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==",
+      "requires": {
+        "tmp": "0.1.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "async": ">=0.2.9",
+    "tmp-promise": "^2.0.2",
     "which": "^1.1.1"
   },
   "engines": {


### PR DESCRIPTION
We were having issues when using FFMPEG with more than ~20 inputs, we got `ENAMETOOLONG` error. We use complex filters a lot to normalize media, apply effects, etc., so we need to pass A LOT of arguments to FFMPEG process. However, when Node.js is trying to pass them to FFMPEG child process, it seems that there's an OS or Node.js limit. See: https://stackoverflow.com/questions/47361935/node-js-child-process-with-a-very-long-argument.

The solution we've implemented is detecting when complex filters argument is greater than 24KB. If so, we'll create a temporary file with the filters into it and use `filter_complex_script` FFMPEG argument passing that file.

After some tests on Windows, we saw that limit was around ~30-31KB, but we preferred to use a lower limit (24KB) just in case.